### PR TITLE
Update tuzuru list command with swift-wcwidth

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b7bb64f3ef96239d70bb58e2f64e045816616f04339c324e40257a770d0815e8",
+  "originHash" : "aa07463b330a0e0f0a7427dda887fc61c7a4e2c50676df58dbc5c726428c30e9",
   "pins" : [
     {
       "identity" : "swift-argument-parser",
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ainame/swift-wcwidth.git",
       "state" : {
-        "revision" : "b5afe47c7b0cdfadc5a70d5bc7e0e0c6ca07e6d8",
-        "version" : "0.0.1"
+        "revision" : "f9cefb1b9fe52789e016c8c51400a88de95f2509",
+        "version" : "0.0.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-system.git", from: "1.5.0"),
         .package(url: "https://github.com/swiftlang/swift-subprocess.git", branch: "main"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "6.1.0"),
-        .package(url: "https://github.com/ainame/swift-wcwidth.git", from: "0.0.1"),
+        .package(url: "https://github.com/ainame/swift-wcwidth.git", from: "0.0.2"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/Sources/Command/ListCommand.swift
+++ b/Sources/Command/ListCommand.swift
@@ -75,18 +75,18 @@ struct ListCommand: AsyncParsableCommand {
     }
 
     private func truncateString(_ string: String, maxLength: Int) -> String {
-        if visualWidth(of: string) <= maxLength {
+        if wcwidth(string) <= maxLength {
             return string
         }
 
         var truncated = ""
         var currentWidth = 0
         let ellipsis = "..."
-        let ellipsisWidth = visualWidth(of: ellipsis)
+        let ellipsisWidth = wcwidth(ellipsis)
         let targetWidth = maxLength - ellipsisWidth
 
         for char in string {
-            let charWidth = visualWidth(of: String(char))
+            let charWidth = wcwidth(char)
             if currentWidth + charWidth > targetWidth {
                 break
             }
@@ -97,18 +97,13 @@ struct ListCommand: AsyncParsableCommand {
         return truncated + ellipsis
     }
 
-    private func visualWidth(of string: String) -> Int {
-        let wcwidth = Wcwidth()
-        return wcwidth(string) ?? string.count
-    }
-
     private func printTableWithBorders(headers: [String], rows: [[String]]) {
         // Calculate column widths
-        var columnWidths = headers.map { visualWidth(of: $0) }
+        var columnWidths = headers.map { wcwidth($0) }
 
         for row in rows {
             for (index, cell) in row.enumerated() {
-                let cellWidth = visualWidth(of: cell)
+                let cellWidth = wcwidth(cell)
                 if cellWidth > columnWidths[index] {
                     columnWidths[index] = cellWidth
                 }
@@ -159,7 +154,7 @@ struct ListCommand: AsyncParsableCommand {
     private func printRow(cells: [String], columnWidths: [Int]) {
         var row = "│"
         for (index, cell) in cells.enumerated() {
-            let cellWidth = visualWidth(of: cell)
+            let cellWidth = wcwidth(cell)
             let padding = columnWidths[index] - cellWidth
             row += " \(cell)\(String(repeating: " ", count: padding)) │"
         }


### PR DESCRIPTION
Previously, `tuzuru list` command was implemented with compromised solution outputting data in CSV format, which works fine for debug purpose. But I'd love to put those data in a table with border to make it readable.

I needed to investigate how to do it and learn `wcwidth`, `ICU`, Unicode's EastAsianWidth.txt, or some equivalent OSS in other languages. As a result, I created https://github.com/ainame/swift-wcwidth based on my research.

`tuzuru list` now use it internally and can draw perfect table even when CJK chars, Thai, Arabic, or emojis appear in the output.


<img width="1373" height="689" alt="Screenshot 2025-09-13 at 17 20 59" src="https://github.com/user-attachments/assets/1efeab32-cf48-4cb4-b099-b7c09f8b22f5" />
