### PR TITLE
fix: inconsistent author highlight in list page

### DIFF
--- a/Sources/TuzuruLib/Resources/templates/list.mustache
+++ b/Sources/TuzuruLib/Resources/templates/list.mustache
@@ -17,7 +17,7 @@
                 <a href="{{url}}">{{title}}</a>
             </h3>
             <p>
-                By {{author}} on {{publishedAt}}
+                By <strong>{{author}}</strong> on {{publishedAt}}
             </p>
             {{#excerpt}}
             <p>{{excerpt}}</p>


### PR DESCRIPTION
The author name in list page wasn't highlighted and the list page looks boring.  
It should be consistent between post and list pages.