### PR TITLE
fix(ci): Update static Linux SDK to Swift 6.2.3

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -12,7 +12,7 @@ env:
   PRODUCT_NAME: tuzuru
   XCODE_VERSION: "26.1"
   # Static Linux SDK - Copy the full command from https://www.swift.org/install/macos/
-  STATIC_SDK_INSTALL_CMD: "swift sdk install https://download.swift.org/swift-6.2-release/static-sdk/swift-6.2-RELEASE/swift-6.2-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz --checksum d2225840e592389ca517bbf71652f7003dbf45ac35d1e57d98b9250368769378"
+  STATIC_SDK_INSTALL_CMD: "swift sdk install https://download.swift.org/swift-6.2.3-release/static-sdk/swift-6.2.3-RELEASE/swift-6.2.3-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz --checksum f30ec724d824ef43b5546e02ca06a8682dafab4b26a99fbb0e858c347e507a2c"
 
 jobs:
   build-and-upload:


### PR DESCRIPTION
## Summary
- Update the static Linux SDK from Swift 6.2 to Swift 6.2.3
- Fixes build failure: "module compiled with Swift 6.2 cannot be imported by the Swift 6.2.3 compiler"

## Test plan
- [ ] Re-run the Release Assets workflow after merging