### PR TITLE
fix(ci): Add --repo flag to gh commands in release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,6 +26,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
-          current=$(gh release view "${{ steps.release.outputs.tag_name }}" --json name --jq '.name // ""')
+          current=$(gh release view "${{ steps.release.outputs.tag_name }}" --repo "${{ github.repository }}" --json name --jq '.name // ""')
           new=$(CURRENT="$current" VERSION="${{ steps.release.outputs.version }}" ruby -e "current = ENV['CURRENT']; current = ENV['VERSION'] if current.nil? || current.empty?; puts current.gsub(/[vV]#{ENV['VERSION']}/, ENV['VERSION'])")
-          [[ "$new" != "$current" ]] && gh release edit "${{ steps.release.outputs.tag_name }}" --title "$new"
+          [[ "$new" != "$current" ]] && gh release edit "${{ steps.release.outputs.tag_name }}" --repo "${{ github.repository }}" --title "$new"


### PR DESCRIPTION
## Summary
- Add `--repo` flag to `gh release view` and `gh release edit` commands
- Fixes "not a git repository" error since there's no checkout step in this workflow

## Test plan
- [ ] Verify the release-please workflow succeeds on next release