### PR TITLE
feat(ci): Use OIDC trusted publisher for npm publishing

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 env:
   PRODUCT_NAME: tuzuru
@@ -136,11 +137,10 @@ jobs:
 
       - name: Publish npm package
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           jq '.version = "'"${VERSION}"'"' package.json > package.json.tmp && mv package.json.tmp package.json
-          npm publish --access public
+          npm publish --provenance --access public
 
   update-formula:
     needs: build-and-upload


### PR DESCRIPTION
## Summary
- Replace `NPM_TOKEN` secret with OIDC-based authentication
- Add `id-token: write` permission for OIDC token generation
- Use `npm publish --provenance` for supply chain security

## Setup Required
Before merging, configure trusted publisher on [npmjs.com](https://www.npmjs.com/package/@ainame/tuzuru/access):

1. Go to package settings → "Trusted Publishers"
2. Add a new trusted publisher with:
   - **Repository**: `ainame/tuzuru`
   - **Workflow filename**: `release-assets.yml`
   - **Environment**: (leave empty)

## Test plan
- [ ] Configure trusted publisher on npmjs.com
- [ ] Merge and trigger a release to verify npm publishing works